### PR TITLE
Fix schema.ts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
       
       - name: Create DB Schema
-        run: npm run schema postgres root
+        run: npm run schema -- --username postgres --password root
 
       - name: Test Backend-Server
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^1.8.1",
     "@nestia/core": "^1.2.2",
+    "commander": "^10.0.1",
     "git-last-commit": "^1.0.0",
     "mutex-server": "^0.3.1",
     "pg": "^8.7.3",

--- a/src/executable/schema.ts
+++ b/src/executable/schema.ts
@@ -52,8 +52,8 @@ async function main(): Promise<void> {
 
     await execute(
         config.database,
-        "postgres",
-        "root",
+        process.argv[2] || "postgres",
+        process.argv[3] || "root",
         `
         GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "${config.schema}" TO "${config.username}";
 


### PR DESCRIPTION
Please consider the following request.

If the administrator account in PostgreSQL is not named 'postgres' and the password is not 'root', an error occurs when calling the execute(...) function.

This case was taken into account when calling execute in the main function (line 34), but it was not handled in the third call (line 54). Therefore, I have corrected the code as in the first call.

### Problem Situation
- docker-compose.yml
```yaml
version: "3"

services:
  postgres:
    image: postgres:latest
    container_name: postgres
    restart: always
    ports:
      - ${postgres_container_port}:5432
    environment:
      postgres_database: ${postgres_database}
      postgres_user: ${postgres_user}
      postgres_password: ${postgres_password}
      TZ: Asia/Seoul
    volumes:
      - data:/var/lib/postgresql/data
    init: true
    tty: true

  pgadmin:
    container_name: pgadmin
    image: dpage/pgadmin4
    restart: always
    volumes:
      - admin:/var/lib/pgadmin
    ports:
      - ${PGADMIN_HOST_PORT}:${PGADMIN_CONTAINER_PORT}
    environment:
      pgadmin_default_email: ${pgadmin_default_email}
      pgadmin_default_password: ${pgadmin_default_password}
      TZ: Asia/Seoul
    init: true

volumes:
  data: {}
```
- .env
```
POSTGRES_HOST=postgres
POSTGRES_DATABASE=postgres
POSTGRES_USER=test
postgres_password=4242
POSTGRES_HOST_PORT=4242
postgres_container_port=5432

PGADMIN_HOST_PORT=8080
pgadmin_container_port=80
PGADMIN_DEFAULT_EMAIL=postgres@mail.com
pgadmin_default_password=4242
```

I have configured the docker-compose file as above and made modifications to DB_ACCOUNT, DB_NAME, etc. as described in the README.md file. Then, I executed the following commands in sequence:

```bash
$> npm i
$> npm build
$> npm schema test 4242
```

After execution, I encountered the following error:
```
error: password authentication failed for user "postgres"
    at Parser.parseErrorMessage (/Users/hyeonsok/Dev/myback/backend/node_modules/pg-protocol/src/parser.ts:369:69)
    at Parser.handlePacket (/Users/hyeonsok/Dev/myback/backend/node_modules/pg-protocol/src/parser.ts:188:21)
    at Parser.parse (/Users/hyeonsok/Dev/myback/backend/node_modules/pg-protocol/src/parser.ts:103:30)
    at Socket.<anonymous> (/Users/hyeonsok/Dev/myback/backend/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:511:28)
    at addChunk (node:internal/streams/readable:332:12)
    at readableAddChunk (node:internal/streams/readable:305:9)
    at Socket.Readable.push (node:internal/streams/readable:242:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  length: 104,
  severity: 'FATAL',
  code: '28P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'auth.c',
  line

: '326',
  routine: 'auth_failed'
}
```

The issue seems to be caused by passing 'postgres' as the username in the above code snippet in schema.ts (lines 13-18).
Could you please review it?

Thank you.