### PR TITLE
Support `pnpm install`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/setup-node@v3
       
       - name: Install Backend-Server
-        run: npm install
+        run: npm install -g pnpm && pnpm install
 
       - name: Compile Backend-Server
-        run: npm run build
+        run: pnpm run build
       
       - name: Create DB Schema
-        run: npm run schema postgres root
+        run: pnpm run schema postgres root
 
       - name: Test Backend-Server
-        run: npm run test -- --reset true
+        run: pnpm run test -- --reset true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       
       - name: Install Backend-Server
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install
 
       - name: Compile Backend-Server
-        run: pnpm run build
+        run: npm run build
       
       - name: Create DB Schema
-        run: pnpm run schema postgres root
+        run: npm run schema postgres root
 
       - name: Test Backend-Server
-        run: pnpm run test -- --reset true
+        run: npm run test -- --reset true

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ prisma/migrations
 
 *.DS_Store
 package-lock.json
+pnpm-lock.yaml
 swagger.json
 .npmrc

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "^5.26.0",
     "chalk": "^4.1.2",
     "cli": "^1.0.1",
+    "commander": "10.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "eslint-plugin-deprecation": "^1.4.1",
     "inquirer": "^8.2.5",
@@ -74,6 +75,7 @@
   },
   "dependencies": {
     "@nestia/core": "^2.4.5",
+    "@nestia/fetcher": "^2.4.5",
     "@nestjs/common": "^10.3.0",
     "@nestjs/core": "^10.3.0",
     "@nestjs/platform-fastify": "^10.3.0",
@@ -86,7 +88,7 @@
     "serialize-error": "^4.1.0",
     "source-map-support": "^0.5.19",
     "tstl": "^2.5.13",
-    "typia": "^5.3.10"
+    "typia": "^5.3.12"
   },
   "private": true
 }

--- a/src/providers/common/AttachmentFileProvider.ts
+++ b/src/providers/common/AttachmentFileProvider.ts
@@ -2,7 +2,7 @@ import { v4 } from "uuid";
 
 import { IAttachmentFile } from "@ORGANIZATION/PROJECT-api/lib/structures/common/IAttachmentFile";
 
-import { Prisma } from ".prisma/client";
+import { Prisma } from "@prisma/client";
 
 export namespace AttachmentFileProvider {
   export namespace json {

--- a/src/utils/EntityUtil.ts
+++ b/src/utils/EntityUtil.ts
@@ -2,7 +2,7 @@ import { HashMap, hash } from "tstl";
 import { equal } from "tstl/ranges";
 import typia from "typia";
 
-import { Prisma, PrismaClient } from ".prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 /**
  * Utility for database entity.


### PR DESCRIPTION
As `pnpm` does not allow indirect package importing through dependency, changed `package.json` following the rule, so that `@samchon/backend` becomes both compatible with `npm` and `pnpm`.