### PR TITLE
SDK mode as keyword

### DIFF
--- a/nestia.config.ts
+++ b/nestia.config.ts
@@ -16,7 +16,8 @@ export const NESTIA_CONFIG: INestiaConfig = {
     ],
     beautify: true,
   },
-  primitive: false,
+  keyword: true,
   simulate: true,
+  primitive: false,
 };
 export default NESTIA_CONFIG;


### PR DESCRIPTION
This pull request updates the configuration in `nestia.config.ts` to adjust property settings for better alignment with the intended behavior of the application.

Configuration changes:

* [`nestia.config.ts`](diffhunk://#diff-268445f384d97a43f48bb1d752e4985578eb1171325d04bf35606761bf7fddd0L19-R21): Reordered and updated properties in the `NESTIA_CONFIG` object. The `keyword` property was added and set to `true`, while the `primitive` property was moved below `simulate` and remains set to `false`.